### PR TITLE
Driver modification

### DIFF
--- a/dynamixel_workbench_single_manager/include/dynamixel_workbench_single_manager/dynamixel_driver.h
+++ b/dynamixel_workbench_single_manager/include/dynamixel_workbench_single_manager/dynamixel_driver.h
@@ -62,7 +62,7 @@ public:
   DynamixelDriver(const std::string& device_name,
                   const int baud_rate,
                   const double publish_rate,
-                  const std::string& frame);
+                  const std::string& joint);
 
   virtual ~DynamixelDriver();
 
@@ -108,7 +108,7 @@ protected:
  std::atomic<bool> motor_busy_;
  std::mutex joint_st_mutex_;
  sensor_msgs::JointState joint_st_;
- std::string frame_;
+ std::string joint_;
 
  // health
  std::atomic<bool> motor_ok_;

--- a/dynamixel_workbench_single_manager/include/dynamixel_workbench_single_manager/dynamixel_driver.h
+++ b/dynamixel_workbench_single_manager/include/dynamixel_workbench_single_manager/dynamixel_driver.h
@@ -59,7 +59,11 @@ namespace dynamixel_workbench_single_manager
 class DynamixelDriver
 {
 public:
-  DynamixelDriver(std::string device_name, int baud_rate, double publish_rate);
+  DynamixelDriver(const std::string& device_name,
+                  const int baud_rate,
+                  const double publish_rate,
+                  const std::string& frame);
+
   virtual ~DynamixelDriver();
 
   bool run();
@@ -104,6 +108,7 @@ protected:
  std::atomic<bool> motor_busy_;
  std::mutex joint_st_mutex_;
  sensor_msgs::JointState joint_st_;
+ std::string frame_;
 
  // health
  std::atomic<bool> motor_ok_;

--- a/dynamixel_workbench_single_manager/include/dynamixel_workbench_single_manager/dynamixel_driver.h
+++ b/dynamixel_workbench_single_manager/include/dynamixel_workbench_single_manager/dynamixel_driver.h
@@ -108,7 +108,7 @@ protected:
  std::atomic<bool> motor_busy_;
  std::mutex joint_st_mutex_;
  sensor_msgs::JointState joint_st_;
- std::string joint_;
+ std::string joint_name_;
 
  // health
  std::atomic<bool> motor_ok_;

--- a/dynamixel_workbench_single_manager/src/dynamixel_driver.cpp
+++ b/dynamixel_workbench_single_manager/src/dynamixel_driver.cpp
@@ -164,14 +164,14 @@ namespace dynamixel_workbench_single_manager
 DynamixelDriver::DynamixelDriver(const std::string& device_name,
                                  const int baud_rate,
                                  const double publish_rate,
-                                 const std::string& frame):
+                                 const std::string& joint):
     device_name_(device_name),
     baud_rate_(baud_rate),
     publish_rate_(publish_rate),
     polling_rate_(MAX_MOTOR_POLLING_RATE),
     motor_busy_(false),
     motor_ok_(true),
-    frame_(frame)
+    joint_(joint)
 {
 
 
@@ -417,10 +417,10 @@ bool DynamixelDriver::initROS()
   poll_motor_timer_ = nh_.createTimer(ros::Duration(1.0/polling_rate_),&DynamixelDriver::pollMotor,this);
 
   // set name field of joint state message
-  if(!frame_.empty())
+  if(!joint_.empty())
   {
     joint_st_.name.resize(1);
-    joint_st_.name.front() = frame_;
+    joint_st_.name.front() = joint_;
   }
 
   return true;
@@ -993,14 +993,14 @@ int main(int argc,char** argv)
   double publish_rate; // hz
   int baud_rate;
   std::string device_id;
-  std::string frame;
+  std::string joint;
   ph.param("publish_rate",publish_rate,50.0);
   ph.param("baud_rate",baud_rate,2000000);
   ph.param("device_id",device_id,std::string("/dev/ttyUSB0"));
-  ph.param("frame", frame, std::string(""));
+  ph.param("joint", joint, std::string(""));
 
   spinner.start();
-  dynamixel_workbench_single_manager::DynamixelDriver d(device_id, baud_rate, publish_rate, frame);
+  dynamixel_workbench_single_manager::DynamixelDriver d(device_id, baud_rate, publish_rate, joint);
   if(d.run())
   {
     ros::waitForShutdown();

--- a/dynamixel_workbench_single_manager/src/dynamixel_driver.cpp
+++ b/dynamixel_workbench_single_manager/src/dynamixel_driver.cpp
@@ -161,13 +161,17 @@ bool verifyBaudRate(int br)
 namespace dynamixel_workbench_single_manager
 {
 
-DynamixelDriver::DynamixelDriver(std::string device_name, int baud_rate,double publish_rate):
+DynamixelDriver::DynamixelDriver(const std::string& device_name,
+                                 const int baud_rate,
+                                 const double publish_rate,
+                                 const std::string& frame):
     device_name_(device_name),
     baud_rate_(baud_rate),
     publish_rate_(publish_rate),
     polling_rate_(MAX_MOTOR_POLLING_RATE),
     motor_busy_(false),
-    motor_ok_(true)
+    motor_ok_(true),
+    frame_(frame)
 {
 
 
@@ -406,11 +410,18 @@ bool DynamixelDriver::initROS()
   {
     joint_st_pub_.publish(getJointState());
   };
-//  publish_joint_st_timer_ = nh_.createTimer(period,&DynamixelDriver::publishMessagesCallback,this);
+  //  publish_joint_st_timer_ = nh_.createTimer(period,&DynamixelDriver::publishMessagesCallback,this);
   publish_joint_st_timer_ = nh_.createTimer(period,publish_js_callback);
 
   // poll motor timer
   poll_motor_timer_ = nh_.createTimer(ros::Duration(1.0/polling_rate_),&DynamixelDriver::pollMotor,this);
+
+  // set name field of joint state message
+  if(!frame_.empty())
+  {
+    joint_st_.name.resize(1);
+    joint_st_.name.front() = frame_;
+  }
 
   return true;
 }
@@ -982,12 +993,14 @@ int main(int argc,char** argv)
   double publish_rate; // hz
   int baud_rate;
   std::string device_id;
+  std::string frame;
   ph.param("publish_rate",publish_rate,50.0);
   ph.param("baud_rate",baud_rate,2000000);
   ph.param("device_id",device_id,std::string("/dev/ttyUSB0"));
+  ph.param("frame", frame, std::string(""));
 
   spinner.start();
-  dynamixel_workbench_single_manager::DynamixelDriver d(device_id,baud_rate,publish_rate);
+  dynamixel_workbench_single_manager::DynamixelDriver d(device_id, baud_rate, publish_rate, frame);
   if(d.run())
   {
     ros::waitForShutdown();

--- a/dynamixel_workbench_single_manager/src/dynamixel_driver.cpp
+++ b/dynamixel_workbench_single_manager/src/dynamixel_driver.cpp
@@ -171,7 +171,7 @@ DynamixelDriver::DynamixelDriver(const std::string& device_name,
     polling_rate_(MAX_MOTOR_POLLING_RATE),
     motor_busy_(false),
     motor_ok_(true),
-    joint_(joint)
+    joint_name_(joint)
 {
 
 
@@ -417,10 +417,14 @@ bool DynamixelDriver::initROS()
   poll_motor_timer_ = nh_.createTimer(ros::Duration(1.0/polling_rate_),&DynamixelDriver::pollMotor,this);
 
   // set name field of joint state message
-  if(!joint_.empty())
+  if(!joint_name_.empty())
   {
     joint_st_.name.resize(1);
-    joint_st_.name.front() = joint_;
+    joint_st_.name.front() = joint_name_;
+  }
+  else
+  {
+    ROS_WARN("No joint name specified for JointState message");
   }
 
   return true;
@@ -993,14 +997,14 @@ int main(int argc,char** argv)
   double publish_rate; // hz
   int baud_rate;
   std::string device_id;
-  std::string joint;
+  std::string joint_name;
   ph.param("publish_rate",publish_rate,50.0);
   ph.param("baud_rate",baud_rate,2000000);
   ph.param("device_id",device_id,std::string("/dev/ttyUSB0"));
-  ph.param("joint", joint, std::string(""));
+  ph.param("joint_name", joint_name, std::string("dynamixel_joint"));
 
   spinner.start();
-  dynamixel_workbench_single_manager::DynamixelDriver d(device_id, baud_rate, publish_rate, joint);
+  dynamixel_workbench_single_manager::DynamixelDriver d(device_id, baud_rate, publish_rate, joint_name);
   if(d.run())
   {
     ros::waitForShutdown();


### PR DESCRIPTION
This PR adds a parameter call `joint` (default ="") with which the user can specify which joint of the URDF to drive with the joint state message output of the Dynamixel. That joint name is then written to the first entry of the joint state message `name` field in the `InitRos` method.

Without it, the joint state and robot state publishers do not know which frames to move with the input joint value from the Dynamixel